### PR TITLE
Issue #6 loading page serving for regular requests

### DIFF
--- a/Services/docker-compose.yml
+++ b/Services/docker-compose.yml
@@ -1,13 +1,13 @@
 services:
   cloudflared:
-    image: cloudflare/cloudflared:latest
+    image: cloudflare/cloudflared:2026.1.2
     container_name: CptcEventsTunnel
     command: tunnel --no-autoupdate run --token ${TOKEN}
     restart: unless-stopped
     networks:
       - CptcEventsNetwork
   reverse-proxy:
-    image: caddy:alpine
+    image: caddy:2.11-alpine
     container_name: CptcEventsProxy
     volumes:
         - ./proxy/Caddyfile:/etc/caddy/Caddyfile:ro
@@ -18,4 +18,4 @@ services:
 
 networks:
   CptcEventsNetwork:
-    external: true
+    internal: true

--- a/Services/docker-compose.yml
+++ b/Services/docker-compose.yml
@@ -18,4 +18,4 @@ services:
 
 networks:
   CptcEventsNetwork:
-    internal: true
+    external: true

--- a/Services/proxy/Caddyfile
+++ b/Services/proxy/Caddyfile
@@ -1,47 +1,32 @@
-# Production environment
+{
+	servers {
+		# Trust X-Forwarded-* headers from Cloudflare Tunnel (private IP ranges)
+		trusted_proxies static private_ranges
+	}
+}
+
 :80 {
-    reverse_proxy https://cptcevents-app.redforest-3d2b7eff.westus2.azurecontainerapps.io {
-        # Pass the correct Host header to upstream
-        header_up Host {upstream_hostport}
-        
-        # Add forwarded headers so ASP.NET Core knows the original request details
-        header_up X-Forwarded-Host {host}
-        header_up X-Forwarded-Proto {scheme}
-        header_up X-Forwarded-For {header.X-Forwarded-For}, {remote_host}
+	reverse_proxy https://cptcevents-app.redforest-3d2b7eff.westus2.azurecontainerapps.io {
+		# Preserve the original Host header for Azure Container Apps TLS
+		header_up Host {upstream_hostport}
 
-        # Handle the HTTPS connection to Azure
-        transport http {
-            tls
-            dial_timeout 2s
-            response_header_timeout 2s
-        }
+		# Set a 2 second timeout before Caddy throws a 504 Gateway Timeout
+		transport http {
+			tls
+			dial_timeout 2s
+			response_header_timeout 2s
+		}
+	}
 
-        # Cold start handling...
-        @coldstart status 503
-        handle_response @coldstart {
-            header X-Coldstart "1"
-            header Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
-            header Pragma "no-cache"
-            header Expires "0"
-            root * /var/www/coldstart
-            rewrite * /loading.html
-            file_server {
-                status 200
-            }
-        }
-    }
-
-    # Error handler...
-    handle_errors {
-        header Content-Type text/html
-        header X-Coldstart "1"
-        header Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
-        header Pragma "no-cache"
-        header Expires "0"
-        root * /var/www/coldstart
-        rewrite * /loading.html
-        file_server {
-            status 200
-        }
-    }
+	# Catch 504 timeout errors and serve loading page
+	handle_errors 504 {
+		header Content-Type text/html
+		header X-Coldstart "1"
+		header Cache-Control "no-store"
+		root * /var/www/coldstart
+		rewrite * /loading.html
+		file_server {
+			status 200
+		}
+	}
 }

--- a/Services/proxy/Caddyfile
+++ b/Services/proxy/Caddyfile
@@ -18,15 +18,24 @@
 		}
 	}
 
-	# Catch 504 timeout errors and serve loading page
+	# Catch 504 timeout errors and serve loading page (only for HTML/navigation requests)
 	handle_errors 504 {
-		header Content-Type text/html
-		header X-Coldstart "1"
-		header Cache-Control "no-store"
-		root * /var/www/coldstart
-		rewrite * /loading.html
-		file_server {
-			status 200
+		@html {
+			header Accept *text/html*
+		}
+		handle @html {
+			header Content-Type text/html
+			header X-Coldstart "1"
+			header Cache-Control "no-store"
+			root * /var/www/coldstart
+			rewrite * /loading.html
+			file_server {
+				status 200
+			}
+		}
+		# Let non-HTML requests (CSS, JS, images) fail with original 504
+		handle {
+			respond "Gateway Timeout" 504
 		}
 	}
 }

--- a/Services/proxy/Caddyfile
+++ b/Services/proxy/Caddyfile
@@ -20,6 +20,9 @@
         @coldstart status 503
         handle_response @coldstart {
             header X-Coldstart "1"
+            header Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+            header Pragma "no-cache"
+            header Expires "0"
             root * /var/www/coldstart
             rewrite * /loading.html
             file_server {
@@ -32,6 +35,9 @@
     handle_errors {
         header Content-Type text/html
         header X-Coldstart "1"
+        header Cache-Control "no-store, no-cache, must-revalidate, max-age=0"
+        header Pragma "no-cache"
+        header Expires "0"
         root * /var/www/coldstart
         rewrite * /loading.html
         file_server {

--- a/Services/proxy/coldstart/loading.html
+++ b/Services/proxy/coldstart/loading.html
@@ -357,7 +357,9 @@
         const urlParams = new URLSearchParams(window.location.search);
         if (!urlParams.has('test')) {
             await pollServer();
-            alert('The server is taking longer than expected to start. Please try refreshing the page.');
+            if (Date.now() - startTime >= MAX_WAIT_TIME) {
+                alert('The server is taking longer than expected to start. Please try refreshing the page.');
+            }
         }
     </script>
 </body>

--- a/Services/proxy/coldstart/loading.html
+++ b/Services/proxy/coldstart/loading.html
@@ -148,7 +148,7 @@
         </div>
     </div>
 
-    <script>
+    <script type="module">
         let mouseX = window.innerWidth / 2;
         let mouseY = window.innerHeight / 2;
         let lastMouseMoveTime = 0;

--- a/Services/proxy/coldstart/loading.html
+++ b/Services/proxy/coldstart/loading.html
@@ -309,7 +309,7 @@
             animate();
         }
 
-        const MAX_WAIT_TIME = 60000;
+        const MAX_WAIT_TIME = 120000;
         const CHECK_INTERVAL = 2000;
         const TIMEOUT = 3000;
 
@@ -356,7 +356,8 @@
         // Only start polling if not in test mode
         const urlParams = new URLSearchParams(window.location.search);
         if (!urlParams.has('test')) {
-            pollServer();
+            await pollServer();
+            alert('The server is taking longer than expected to start. Please try refreshing the page.');
         }
     </script>
 </body>


### PR DESCRIPTION
Closes #6

This pull request updates the reverse proxy and cold start handling for the service, focusing on improved timeout management, better error handling, and enhanced client-side feedback during server cold starts. The changes include updating Docker image versions, refining proxy configuration for trust and error handling, and improving the cold start loading page for user experience.

**Proxy and Docker image updates:**
- Updated the `cloudflared` and `caddy` Docker images to specific, newer versions for improved stability and security.

**Reverse proxy configuration improvements:**
- Enhanced the `Caddyfile` to trust forwarded headers from Cloudflare, set explicit timeouts for upstream connections, and improved error handling by serving a loading page on 504 Gateway Timeout errors.

**Cold start loading page enhancements:**
- Changed the loading page script to use ES module syntax for better maintainability.
- Increased the maximum wait time for server readiness from 60 seconds to 120 seconds, giving more time for cold starts.
- Improved user feedback by showing an alert if the server takes too long to start, prompting the user to refresh the page.