### PR TITLE
Update server health check to treat non-2xx responses as not ready

### DIFF
--- a/Services/proxy/coldstart/loading.html
+++ b/Services/proxy/coldstart/loading.html
@@ -326,8 +326,10 @@
             })
                 .then(response => {
                     clearTimeout(timeoutId);
+                    // Treat non-2xx responses (like 504) as not ready
+                    if (!response.ok) return false;
                     // Server is ready only if we don't have the coldstart header
-                    // (Caddy intercepts 503 and returns 200 with X-Coldstart header)
+                    // (Caddy may intercept and return 200 with X-Coldstart header)
                     const hasColdstartHeader = response.headers.get('X-Coldstart') === '1';
                     return !hasColdstartHeader;
                 })


### PR DESCRIPTION
This pull request improves the readiness check logic in the `loading.html` file to more accurately determine when the server is ready, especially in cases where the server returns non-2xx responses.

Readiness check improvements:

* Updated the fetch logic to treat any non-2xx HTTP response (such as 504) as "not ready", ensuring the client waits for a proper server response before proceeding.
* Clarified the comment to explain that Caddy may intercept and return a 200 status with an `X-Coldstart` header, rather than always intercepting 503 responses.